### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that enables running and managing long-running background tasks from within Claude Desktop or other MCP-compatible clients.
 
+<a href="https://glama.ai/mcp/servers/@nanoseil/mcp-bgtask">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@nanoseil/mcp-bgtask/badge" alt="Background Task Server MCP server" />
+</a>
+
 ## Features
 
 - **Run Background Tasks**: Execute long-running commands (like `npm run dev`, servers, builds) in the background


### PR DESCRIPTION
This PR adds a badge for the [MCP Background Task Server](https://glama.ai/mcp/servers/@nanoseil/mcp-bgtask) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@nanoseil/mcp-bgtask">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@nanoseil/mcp-bgtask/badge" alt="Background Task Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.